### PR TITLE
Bugfix for Noble Sacrifice

### DIFF
--- a/hearthbreaker/cards/spells/paladin.py
+++ b/hearthbreaker/cards/spells/paladin.py
@@ -230,7 +230,7 @@ class NobleSacrifice(SecretCard):
                          CARD_RARITY.COMMON)
 
     def _reveal(self, attacker, target):
-        player = attacker.game.other_player
+        player = attacker.player.game.other_player
         if len(player.minions) < 7 and not attacker.removed:
             class DefenderMinion(MinionCard):
                 def __init__(self):

--- a/tests/card_tests/paladin_tests.py
+++ b/tests/card_tests/paladin_tests.py
@@ -558,3 +558,17 @@ class TestPaladin(unittest.TestCase):
 
         self.assertEqual(0, len(game.other_player.minions))
         self.assertEqual(1, len(game.other_player.secrets))
+
+    def test_NobleSacrifice_hero(self):
+        game = generate_game_for(NobleSacrifice, Naturalize, OneCardPlayingAgent, PredictableAgent)
+        for turn in range(0, 3):
+            game.play_single_turn()
+
+        self.assertEqual(1, len(game.players[0].secrets))
+        self.assertEqual(30, game.players[0].hero.health)
+        self.assertEqual(30, game.players[1].hero.health)
+
+        game.play_single_turn()
+        self.assertEqual(0, len(game.players[0].secrets))
+        self.assertEqual(30, game.players[0].hero.health)
+        self.assertEqual(29, game.players[1].hero.health)


### PR DESCRIPTION
The attacker can be a hero, who doesn't have the game object.
