### PR TITLE
Fix for Jaraxxus's Infernal and for Mirror Image when copied.

### DIFF
--- a/hearthbreaker/cards/minions/warlock.py
+++ b/hearthbreaker/cards/minions/warlock.py
@@ -118,6 +118,15 @@ class LordJaraxxus(MinionCard):
         return Minion(3, 15, battlecry=summon_jaraxxus)
 
 
+class Infernal(MinionCard):
+    def __init__(self):
+        super().__init__("Infernal", 6, CHARACTER_CLASS.LORD_JARAXXUS, CARD_RARITY.SPECIAL,
+                         minion_type=MINION_TYPE.DEMON)
+
+    def create_minion(self, player):
+        return Minion(6, 6)
+
+
 class VoidTerror(MinionCard):
     def __init__(self):
         super().__init__("Void Terror", 3, CHARACTER_CLASS.WARLOCK, CARD_RARITY.RARE, MINION_TYPE.DEMON)

--- a/hearthbreaker/cards/spells/mage.py
+++ b/hearthbreaker/cards/spells/mage.py
@@ -34,25 +34,22 @@ class IceLance(Card):
             self.target.freeze()
 
 
+class MirrorImageMinion(MinionCard):
+    def __init__(self):
+        super().__init__("Mirror Image", 0, CHARACTER_CLASS.MAGE, CARD_RARITY.SPECIAL, ref_name="Mirror Image (minion)")
+
+    def create_minion(self, p):
+        return Minion(0, 2, taunt=True)
+
+
 class MirrorImage(Card):
     def __init__(self):
         super().__init__("Mirror Image", 1, CHARACTER_CLASS.MAGE, CARD_RARITY.COMMON)
 
     def use(self, player, game):
         super().use(player, game)
-
-        class MirrorImageMinion(MinionCard):
-            def __init__(self):
-                super().__init__("Mirror Image", 0, CHARACTER_CLASS.MAGE, CARD_RARITY.SPECIAL)
-
-            def create_minion(self, p):
-                minion = Minion(0, 2)
-                minion.taunt = True
-                return minion
-
         for i in range(0, 2):
-            mirror_image = MirrorImageMinion()
-            mirror_image.summon(player, game, len(player.minions))
+            MirrorImageMinion().summon(player, game, len(player.minions))
 
 
 class ArcaneExplosion(Card):

--- a/hearthbreaker/constants.py
+++ b/hearthbreaker/constants.py
@@ -48,6 +48,7 @@ class CHARACTER_CLASS:
         "PALADIN": PALADIN,
         "ROGUE": ROGUE,
         "WARLOCK": WARLOCK,
+        "LORD_JARAXXUS": LORD_JARAXXUS,
         "": ALL,
     }
 

--- a/hearthbreaker/powers.py
+++ b/hearthbreaker/powers.py
@@ -206,17 +206,9 @@ class JaraxxusPower(Power):
         super().__init__(hero)
 
     def use(self):
-        class Infernal(hearthbreaker.game_objects.MinionCard):
-            def __init__(self):
-                super().__init__("Infernal", 6, hearthbreaker.constants.CHARACTER_CLASS.LORD_JARAXXUS,
-                                 hearthbreaker.constants.CARD_RARITY.SPECIAL)
-
-            def create_minion(self, player):
-                return hearthbreaker.game_objects.Minion(6, 6, hearthbreaker.constants.MINION_TYPE.DEMON)
-
         super().use()
 
-        infernal_card = Infernal()
+        infernal_card = hearthbreaker.cards.minions.warlock.Infernal()
         infernal_card.summon(self.hero.player, self.hero.player.game, len(self.hero.player.minions))
 
 


### PR DESCRIPTION
Infernal's minion type was not being set correctly.

Mirror Image's name was causing confusion when looking it up.

Closes #80 and closes #81