### PR TITLE
Card attachment fixes

### DIFF
--- a/hearthbreaker/cards/base.py
+++ b/hearthbreaker/cards/base.py
@@ -312,6 +312,7 @@ class MinionCard(Card, metaclass=abc.ABCMeta):
         :param int index: The index where the new minion will be added
         """
         if len(player.minions) < 7:
+            self.attach(self, player)
             minion = self.create_minion(player)
             minion.card = self
             minion.player = player


### PR DESCRIPTION
This is a fix for every card that uses .summon() directly (spells).
* Mirror Image
* I Am Murloc
* Poison Seeds
* Many others...