### PR TITLE
Implemented Emperor Thaurissan.

### DIFF
--- a/card_defs.json
+++ b/card_defs.json
@@ -4379,12 +4379,31 @@
     "rarity": "Epic"
   }, 
   {
-    "mana": 4, 
-    "attack": 3, 
-    "health": 3, 
+    "collectible": true, 
+    "buffs": [
+      {
+        "status": {
+          "amount": {
+            "attribute": "attack", 
+            "name": "attribute", 
+            "selector": {
+              "players": "friendly", 
+              "name": "weapon"
+            }
+          }, 
+          "name": "mana_change", 
+          "multiplier": -1
+        }
+      }
+    ], 
     "name": "Dread Corsair", 
     "minion_type": "Pirate", 
     "character_class": "", 
+    "rarity": "Common", 
+    "mana": 4, 
+    "attack": 3, 
+    "health": 3, 
+    "type": "minion", 
     "impl": {
       "buffs": [
         {
@@ -4393,10 +4412,7 @@
           }
         }
       ]
-    }, 
-    "type": "minion", 
-    "collectible": true, 
-    "rarity": "Common"
+    }
   }, 
   {
     "mana": 2, 
@@ -7986,6 +8002,47 @@
     "type": "minion", 
     "collectible": true, 
     "rarity": "Rare"
+  }, 
+  {
+    "mana": 6, 
+    "attack": 5, 
+    "health": 5, 
+    "name": "Emperor Thaurissan", 
+    "character_class": "", 
+    "impl": {
+      "effects": [
+        {
+          "event": {
+            "event_name": "turn_ended", 
+            "player": "friendly"
+          }, 
+          "tags": [
+            {
+              "actions": [
+                {
+                  "name": "give", 
+                  "buffs": [
+                    {
+                      "status": {
+                        "amount": -1, 
+                        "name": "mana_change"
+                      }
+                    }
+                  ]
+                }
+              ], 
+              "selector": {
+                "players": "friendly", 
+                "name": "card"
+              }
+            }
+          ]
+        }
+      ]
+    }, 
+    "type": "minion", 
+    "collectible": true, 
+    "rarity": "Legendary"
   }, 
   {
     "mana": 1, 

--- a/hearthbreaker/agents/trade/possible_play.py
+++ b/hearthbreaker/agents/trade/possible_play.py
@@ -15,12 +15,12 @@ class PossiblePlay:
             if card.name == "The Coin":
                 return -1
             else:
-                return card.mana_cost(card.player)
+                return card.mana_cost()
 
         return reduce(lambda s, c: s + eff_mana(c), self.cards, 0)
 
     def sorted_mana(self):
-        return Util.reverse_sorted(map(lambda c: c.mana_cost(c.player), self.cards))
+        return Util.reverse_sorted(map(lambda c: c.mana_cost(), self.cards))
 
     def wasted(self):
         return self.available_mana - self.card_mana()
@@ -115,7 +115,7 @@ class HeroPowerCard:
     def can_use(self, player, game):
         return True
 
-    def mana_cost(self, player):
+    def mana_cost(self):
         return 2
 
 
@@ -159,12 +159,12 @@ class PossiblePlays(CoinPlays):
 
             if card.name == 'Hero Power':
                 f_plays = PossiblePlays(rest,
-                                        self.mana - card.mana_cost(card.player),
+                                        self.mana - card.mana_cost(),
                                         allow_hero_power=False).raw_plays()
             else:
                 rest.remove(card)
                 f_plays = PossiblePlays(rest,
-                                        self.mana - card.mana_cost(card.player),
+                                        self.mana - card.mana_cost(),
                                         allow_hero_power=self.allow_hero_power).raw_plays()
 
             for following_play in f_plays:

--- a/hearthbreaker/cards/base.py
+++ b/hearthbreaker/cards/base.py
@@ -100,16 +100,15 @@ class Card(Bindable, GameObject):
         """
         if game.game_ended:
             return False
-        return player.mana >= self.mana_cost(player)
+        return player.mana >= self.mana_cost()
 
-    def mana_cost(self, player):
+    def mana_cost(self):
         """
         Calculates the mana cost for this card.
 
         This cost is the base cost for the card, modified by any tags from the card itself, or
         from other cards (such as :class:`hearthbreaker.cards.minions.neutral.VentureCoMercenary`)
 
-        :param hearthbreaker.game_objects.Player player: The player who is trying to use the card.
 
         :return: representing the actual mana cost of this card.
         :rtype: int
@@ -439,14 +438,12 @@ class SpellCard(Card, metaclass=abc.ABCMeta):
 
         return super().can_use(player, game)
 
-    def mana_cost(self, player):
+    def mana_cost(self):
         """
         Calculates the mana cost for this card.
 
         This cost is the base cost for the card, modified by any tags from the card itself, or
         from other cards (such as :class:`hearthbreaker.cards.minions.neutral.VentureCoMercenary`)
-
-        :param hearthbreaker.game_objects.Player player: The player who is trying to use the card.
 
         :return: representing the actual mana cost of this card.
         :rtype: int

--- a/hearthbreaker/cards/minions/__init__.py
+++ b/hearthbreaker/cards/minions/__init__.py
@@ -232,6 +232,7 @@ from hearthbreaker.cards.minions.neutral import (
     HungryDragon,
     GrimPatron,
     BlackwingTechnician,
+    EmperorThaurissan,
 )
 
 from hearthbreaker.cards.minions.druid import (

--- a/hearthbreaker/cards/minions/neutral.py
+++ b/hearthbreaker/cards/minions/neutral.py
@@ -1400,19 +1400,11 @@ class SeaGiant(MinionCard):
 
 class DreadCorsair(MinionCard):
     def __init__(self):
-        super().__init__("Dread Corsair", 4, CHARACTER_CLASS.ALL, CARD_RARITY.COMMON, minion_type=MINION_TYPE.PIRATE)
+        super().__init__("Dread Corsair", 4, CHARACTER_CLASS.ALL, CARD_RARITY.COMMON, minion_type=MINION_TYPE.PIRATE,
+                         buffs=[Buff(ManaChange(Attribute("attack", WeaponSelector()), -1))])
 
     def create_minion(self, player):
         return Minion(3, 3, taunt=True)
-
-    def mana_cost(self, player):
-        if player.hero.weapon:
-            cost = super().mana_cost(player) - player.hero.weapon.base_attack
-        else:
-            return 4
-        if cost < 0:
-            return 0
-        return cost
 
 
 class CaptainsParrot(MinionCard):
@@ -2477,3 +2469,11 @@ class GrimPatron(MinionCard):
         return Minion(3, 3, effects=[Effect(Damaged(), [ActionTag(Summon(GrimPatron()), PlayerSelector(),
                                                                   GreaterThan(Attribute("health", SelfSelector()),
                                                                               value=0))])])
+
+
+class EmperorThaurissan(MinionCard):
+    def __init__(self):
+        super().__init__("Emperor Thaurissan", 6, CHARACTER_CLASS.ALL, CARD_RARITY.LEGENDARY)
+
+    def create_minion(self, player):
+        return Minion(5, 5, effects=[Effect(TurnEnded(), [ActionTag(Give(Buff(ManaChange(-1))), CardSelector())])])

--- a/hearthbreaker/cards/spells/warrior.py
+++ b/hearthbreaker/cards/spells/warrior.py
@@ -2,9 +2,10 @@ import copy
 from hearthbreaker.cards.base import SpellCard
 from hearthbreaker.tags.action import Damage, Draw, Discard
 from hearthbreaker.tags.base import AuraUntil, Buff, Effect, CardQuery, CARD_SOURCE, ActionTag
+from hearthbreaker.tags.condition import GreaterThan, IsDamaged
 from hearthbreaker.tags.event import TurnEnded, Drawn
-from hearthbreaker.tags.selector import MinionSelector, HeroSelector, PlayerSelector
-from hearthbreaker.tags.status import Charge as _Charge, MinimumHealth
+from hearthbreaker.tags.selector import MinionSelector, HeroSelector, PlayerSelector, Count
+from hearthbreaker.tags.status import Charge as _Charge, MinimumHealth, ManaChange
 import hearthbreaker.targeting
 import hearthbreaker.tags.action
 from hearthbreaker.constants import CHARACTER_CLASS, CARD_RARITY
@@ -235,16 +236,8 @@ class BouncingBlade(SpellCard):
 class Crush(SpellCard):
     def __init__(self):
         super().__init__("Crush", 7, CHARACTER_CLASS.WARRIOR, CARD_RARITY.EPIC,
-                         target_func=hearthbreaker.targeting.find_minion_spell_target)
-
-    def mana_cost(self, player):
-        damaged_minion_discount = 0
-        for minion in player.game.current_player.minions:
-            if minion.health != minion.calculate_max_health():
-                damaged_minion_discount = 4
-                break
-        cost = super().mana_cost(player) - damaged_minion_discount
-        return cost
+                         target_func=hearthbreaker.targeting.find_minion_spell_target,
+                         buffs=[Buff(ManaChange(-4), GreaterThan(Count(MinionSelector(IsDamaged())), value=0))])
 
     def use(self, player, game):
         super().use(player, game)

--- a/hearthbreaker/engine.py
+++ b/hearthbreaker/engine.py
@@ -237,7 +237,7 @@ class Game(Bindable):
             raise GameException("That card cannot be used")
         card_index = self.current_player.hand.index(card)
         self.current_player.hand.pop(card_index)
-        self.current_player.mana -= card.mana_cost(self.current_player)
+        self.current_player.mana -= card.mana_cost()
         self._all_cards_played.append(card)
         card.target = None
         card.current_target = None

--- a/hearthbreaker/game_objects.py
+++ b/hearthbreaker/game_objects.py
@@ -786,6 +786,13 @@ class Weapon(Bindable, GameObject):
         self.attach(self, player)
         self.player.hero.trigger("weapon_equipped")
 
+    def calculate_attack(self):
+        """
+        Calculates the amount of attack this :class:`Wea[on` has, including the base attack, any temporary attack
+        bonuses for this turn
+        """
+        return self.calculate_stat(ChangeAttack, self.base_attack)
+
     def __to_json__(self):
         parent_json = super().__to_json__()
         parent_json.update({

--- a/hearthbreaker/tags/action.py
+++ b/hearthbreaker/tags/action.py
@@ -695,7 +695,7 @@ class SwapStats(Action):
                 if not was_enraged:
                     obj._do_enrage()
         elif attribute == 'mana':
-            obj.add_buff(Buff(ManaChange(value - obj.mana_cost(None))))
+            obj.add_buff(Buff(ManaChange(value - obj.mana_cost())))
         elif attribute == "attack":
             obj.add_buff(Buff(SetAttack(value)))
         elif attribute == "health":

--- a/hearthbreaker/ui/game_printer.py
+++ b/hearthbreaker/ui/game_printer.py
@@ -110,7 +110,7 @@ class GameRender:
                 color = curses.color_pair(3)
 
         name = card.name[:15]
-        window.addstr(y + 0, x, " {0:>2} mana ({1})   ".format(card.mana_cost(player), status), color)
+        window.addstr(y + 0, x, " {0:>2} mana ({1})   ".format(card.mana_cost(), status), color)
         window.addstr(y + 1, x, "{0:^15}".format(name), color)
 
     def draw_hero(self, hero, window, x, y):

--- a/tests/card_tests/hunter_tests.py
+++ b/tests/card_tests/hunter_tests.py
@@ -230,7 +230,7 @@ class TestHunter(unittest.TestCase):
         self.assertEqual(0, len(game.players[1].minions))
         self.assertEqual(4, len(game.players[0].hand))
         self.assertEqual(7, len(game.players[1].hand))
-        self.assertEqual(4, game.players[1].hand[6].mana_cost(game.players[1]))
+        self.assertEqual(4, game.players[1].hand[6].mana_cost())
         self.assertEqual(0, len(game.players[0].secrets))
         self.assertEqual(30, game.players[0].hero.health)
         game.play_single_turn()
@@ -239,8 +239,8 @@ class TestHunter(unittest.TestCase):
         self.assertEqual(0, len(game.current_player.minions))
         self.assertEqual(30, game.players[0].hero.health)
         self.assertEqual(8, len(game.players[1].hand))
-        self.assertEqual(4, game.players[1].hand[5].mana_cost(game.players[1]))
-        self.assertEqual(4, game.players[1].hand[7].mana_cost(game.players[1]))
+        self.assertEqual(4, game.players[1].hand[5].mana_cost())
+        self.assertEqual(4, game.players[1].hand[7].mana_cost())
 
     def test_FreezingTrap_many_cards(self):
         class FreezingTrapAgent(DoNothingAgent):
@@ -265,7 +265,7 @@ class TestHunter(unittest.TestCase):
         self.assertEqual(0, len(game.current_player.minions))
         for card in game.current_player.hand:
             if card.name != "The Coin":
-                self.assertEqual(6, card.mana_cost(game.current_player))
+                self.assertEqual(6, card.mana_cost())
         self.assertEqual(30, game.other_player.hero.health)
         death_mock.assert_called_once_with(None)
 
@@ -299,7 +299,7 @@ class TestHunter(unittest.TestCase):
         # Freezing Trap triggers, bouncing the charging Wolfrider
         self.assertEqual(0, len(game.players[1].minions))
         self.assertEqual(8, len(game.players[1].hand))
-        self.assertEqual(5, game.players[1].hand[7].mana_cost(game.players[1]))
+        self.assertEqual(5, game.players[1].hand[7].mana_cost())
         self.assertEqual(4, len(game.players[0].hand))
         self.assertEqual(30, game.other_player.hero.health)
         self.assertEqual(30, game.current_player.hero.health)
@@ -603,13 +603,13 @@ class TestHunter(unittest.TestCase):
 
         # King Krush should cost 4 less (9 - 4 = 5)
         self.assertEqual(5, len(game.players[0].hand))
-        self.assertEqual(5, game.players[0].hand[4].mana_cost(game.players[0]))
+        self.assertEqual(5, game.players[0].hand[4].mana_cost())
 
         for turn in range(0, 2):
             game.play_single_turn()
 
         # Molten Giant should not be affected since it's not a beast
-        self.assertEqual(20, game.players[0].hand[5].mana_cost(game.players[0]))
+        self.assertEqual(20, game.players[0].hand[5].mana_cost())
 
     def test_CobraShot(self):
         game = generate_game_for(CobraShot, StonetuskBoar, CardTestingAgent, CardTestingAgent)

--- a/tests/card_tests/mage_tests.py
+++ b/tests/card_tests/mage_tests.py
@@ -212,8 +212,8 @@ class TestMage(unittest.TestCase):
         self.assertEqual(27, game.other_player.hero.health)
 
         # Make sure the other frostbolts have been properly reduced
-        self.assertEqual(1, game.current_player.hand[1].mana_cost(game.current_player))
-        self.assertEqual(1, game.current_player.hand[2].mana_cost(game.current_player))
+        self.assertEqual(1, game.current_player.hand[1].mana_cost())
+        self.assertEqual(1, game.current_player.hand[2].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
@@ -222,7 +222,7 @@ class TestMage(unittest.TestCase):
         self.assertEqual(0, len(game.current_player.minions))
 
         # Make sure that the cards in hand are no longer reduced
-        self.assertEqual(2, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(2, game.current_player.hand[0].mana_cost())
 
     def test_ArcaneIntellect(self):
         game = generate_game_for(ArcaneIntellect, StonetuskBoar, CardTestingAgent, DoNothingAgent)
@@ -432,7 +432,7 @@ class TestMage(unittest.TestCase):
         self.assertEqual("Vaporize", game.current_player.secrets[0].name)
         self.assertEqual(1, len(game.current_player.minions))
         self.assertEqual("Kirin Tor Mage", game.current_player.minions[0].card.name)
-        self.assertEqual(3, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(3, game.current_player.hand[0].mana_cost())
         self.assertEqual("Spellbender", game.current_player.hand[0].name)
 
         random.seed(1857)
@@ -443,7 +443,7 @@ class TestMage(unittest.TestCase):
         self.assertEqual(0, len(game.current_player.secrets))
         self.assertEqual(1, len(game.current_player.minions))
         self.assertEqual("Kirin Tor Mage", game.current_player.minions[0].card.name)
-        self.assertEqual(3, game.current_player.hand[2].mana_cost(game.current_player))
+        self.assertEqual(3, game.current_player.hand[2].mana_cost())
         self.assertEqual("Vaporize", game.current_player.hand[2].name)
 
     def test_EtherealArcanist(self):
@@ -862,7 +862,7 @@ class TestMage(unittest.TestCase):
         self.assertTrue(game.current_player.hand[-1].is_minion())
         if game.current_player.hand[-1].mana >= 3:
             # TODO This assertion may fail, if unstable portal summons a Giant.  Don't know how to solve that issue
-            self.assertEqual(3, game.current_player.hand[-1].mana - game.current_player.hand[-1].mana_cost(None))
+            self.assertEqual(3, game.current_player.hand[-1].mana - game.current_player.hand[-1].mana_cost())
 
     def test_DragonsBreath(self):
         game = generate_game_for([Flamestrike, DragonsBreath], StonetuskBoar, CardTestingAgent, OneCardPlayingAgent)

--- a/tests/card_tests/neutral_tests.py
+++ b/tests/card_tests/neutral_tests.py
@@ -1183,13 +1183,13 @@ class TestCommon(unittest.TestCase, TestUtilities):
         for turn in range(0, 10):
             game.play_single_turn()
 
-        self.assertEqual(0, game.players[0].hand[0].mana_cost(game.players[0]))
-        self.assertEqual(8, game.players[0].hand[1].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[0].mana_cost())
+        self.assertEqual(8, game.players[0].hand[1].mana_cost())
 
         game.play_single_turn()
 
-        self.assertEqual(5, game.players[0].hand[0].mana_cost(game.players[0]))
-        self.assertEqual(0, game.players[0].hand[1].mana_cost(game.players[0]))
+        self.assertEqual(5, game.players[0].hand[0].mana_cost())
+        self.assertEqual(0, game.players[0].hand[1].mana_cost())
 
     def test_Demolisher(self):
         game = generate_game_for(Demolisher, StonetuskBoar, OneCardPlayingAgent, DoNothingAgent)
@@ -1473,15 +1473,15 @@ class TestCommon(unittest.TestCase, TestUtilities):
         for turn in range(0, 4):
             game.play_single_turn()
 
-        self.assertEqual(0, game.players[0].hand[0].mana_cost(game.players[0]))
-        self.assertEqual(3, game.players[0].hand[1].mana_cost(game.players[0]))
-        self.assertEqual(2, game.players[1].hand[0].mana_cost(game.players[1]))
+        self.assertEqual(0, game.players[0].hand[0].mana_cost())
+        self.assertEqual(3, game.players[0].hand[1].mana_cost())
+        self.assertEqual(2, game.players[1].hand[0].mana_cost())
 
         game.play_single_turn()
 
-        self.assertEqual(2, game.players[0].hand[0].mana_cost(game.players[0]))
-        self.assertEqual(0, game.players[0].hand[1].mana_cost(game.players[0]))
-        self.assertEqual(1, game.players[1].hand[0].mana_cost(game.players[1]))
+        self.assertEqual(2, game.players[0].hand[0].mana_cost())
+        self.assertEqual(0, game.players[0].hand[1].mana_cost())
+        self.assertEqual(1, game.players[1].hand[0].mana_cost())
 
     def test_MindControlTech(self):
         game = generate_game_for(MindControlTech, StonetuskBoar, OneCardPlayingAgent, OneCardPlayingAgent)
@@ -1989,37 +1989,37 @@ class TestCommon(unittest.TestCase, TestUtilities):
 
         game.play_single_turn()
 
-        self.assertEqual(8, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(8, game.current_player.hand[0].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(7, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(7, game.current_player.hand[0].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(6, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(6, game.current_player.hand[0].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(5, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(5, game.current_player.hand[0].mana_cost())
 
         # Play the mountain giant (it costs 4 mana, then the subsequent ones cost 5)
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(5, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(5, game.current_player.hand[0].mana_cost())
         self.assertEqual(1, len(game.current_player.minions))
 
     def test_MoltenGiant(self):
         game = generate_game_for(MoltenGiant, StonetuskBoar, DoNothingAgent, DoNothingAgent)
 
         game.play_single_turn()
-        self.assertEqual(20, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(20, game.current_player.hand[0].mana_cost())
 
         game.current_player.hero.damage(10, None)
-        self.assertEqual(10, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(10, game.current_player.hand[0].mana_cost())
 
         game.current_player.hero.damage(15, None)
-        self.assertEqual(0, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(0, game.current_player.hand[0].mana_cost())
 
     def test_SeaGiant(self):
         game = generate_game_for([SeaGiant, SummoningPortal], StonetuskBoar, OneCardPlayingAgent, CardTestingAgent)
@@ -2027,29 +2027,29 @@ class TestCommon(unittest.TestCase, TestUtilities):
         game.play_single_turn()
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(9, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(9, game.current_player.hand[0].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(7, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(7, game.current_player.hand[0].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(4, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(2, game.current_player.hand[1].mana_cost(game.current_player))
+        self.assertEqual(4, game.current_player.hand[0].mana_cost())
+        self.assertEqual(2, game.current_player.hand[1].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(0, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(0, game.current_player.hand[0].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(2, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(0, game.current_player.hand[1].mana_cost(game.current_player))
+        self.assertEqual(2, game.current_player.hand[0].mana_cost())
+        self.assertEqual(0, game.current_player.hand[1].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(0, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(0, game.current_player.hand[0].mana_cost())
 
     def test_DreadCorsair(self):
         game = generate_game_for([DreadCorsair, LightsJustice, GladiatorsLongbow],
@@ -2058,17 +2058,17 @@ class TestCommon(unittest.TestCase, TestUtilities):
             game.play_single_turn()  # Play 4 mana dread corsair
 
         self.assertEqual(1, len(game.players[0].minions))
-        self.assertEqual(4, game.players[0].hand[2].mana_cost(game.players[0]))
+        self.assertEqual(4, game.players[0].hand[2].mana_cost())
 
         game.play_single_turn()  # Equip LJ and check
 
         self.assertEqual(1, game.players[0].hero.weapon.base_attack)
-        self.assertEqual(3, game.players[0].hand[1].mana_cost(game.players[0]))
+        self.assertEqual(3, game.players[0].hand[1].mana_cost())
 
         for turn in range(0, 4):
             game.play_single_turn()  # Equip longbow and check
 
-        self.assertEqual(0, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[0].mana_cost())
 
     def test_CaptainsParrot(self):
         game = generate_game_for([CaptainsParrot, DreadCorsair, StonetuskBoar], StonetuskBoar,
@@ -2279,12 +2279,12 @@ class TestCommon(unittest.TestCase, TestUtilities):
         game.play_single_turn()
 
         self.assertEqual(1, len(game.players[0].minions))
-        self.assertEqual(2, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(2, game.players[0].hand[0].mana_cost())
 
         # Make sure the summoner's buff is being removed at the end of each turn
         game.play_single_turn()
         game.play_single_turn()
-        self.assertEqual(2, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(2, game.players[0].hand[0].mana_cost())
 
     def test_OldMurkEye(self):
         game = generate_game_for([OldMurkEye, ArcaneExplosion], BluegillWarrior,
@@ -2638,13 +2638,13 @@ class TestCommon(unittest.TestCase, TestUtilities):
             game.play_single_turn()
 
         self.assertEqual(1, len(game.current_player.minions))
-        self.assertEqual(5, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(4, game.other_player.hand[0].mana_cost(game.other_player))
-        self.assertEqual(3, game.other_player.hand[1].mana_cost(game.other_player))
+        self.assertEqual(5, game.current_player.hand[0].mana_cost())
+        self.assertEqual(4, game.other_player.hand[0].mana_cost())
+        self.assertEqual(3, game.other_player.hand[1].mana_cost())
         game.current_player.minions[0].silence()
-        self.assertEqual(3, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(2, game.other_player.hand[0].mana_cost(game.other_player))
-        self.assertEqual(3, game.other_player.hand[1].mana_cost(game.other_player))
+        self.assertEqual(3, game.current_player.hand[0].mana_cost())
+        self.assertEqual(2, game.other_player.hand[0].mana_cost())
+        self.assertEqual(3, game.other_player.hand[1].mana_cost())
 
     def test_NerubarWeblord_with_combo_and_choose(self):
         game = generate_game_for(NerubarWeblord,
@@ -2654,12 +2654,12 @@ class TestCommon(unittest.TestCase, TestUtilities):
         for turn in range(0, 5):
             game.play_single_turn()
 
-        self.assertEqual(4, game.other_player.hand[0].mana_cost(game.other_player))
-        self.assertEqual(7, game.other_player.hand[1].mana_cost(game.other_player))
-        self.assertEqual(6, game.other_player.hand[2].mana_cost(game.other_player))
-        self.assertEqual(2, game.other_player.hand[3].mana_cost(game.other_player))
+        self.assertEqual(4, game.other_player.hand[0].mana_cost())
+        self.assertEqual(7, game.other_player.hand[1].mana_cost())
+        self.assertEqual(6, game.other_player.hand[2].mana_cost())
+        self.assertEqual(2, game.other_player.hand[3].mana_cost())
         # Skip the coin
-        self.assertEqual(3, game.other_player.hand[5].mana_cost(game.other_player))
+        self.assertEqual(3, game.other_player.hand[5].mana_cost())
 
     def test_UnstableGhoul(self):
         game = generate_game_for([StonetuskBoar, FaerieDragon, GoldshireFootman, Frostbolt], UnstableGhoul,
@@ -2681,13 +2681,13 @@ class TestCommon(unittest.TestCase, TestUtilities):
         for turn in range(0, 9):
             game.play_single_turn()
 
-        self.assertEqual(10, game.other_player.hand[0].mana_cost(game.other_player))
-        self.assertEqual(6, game.other_player.hand[1].mana_cost(game.other_player))
+        self.assertEqual(10, game.other_player.hand[0].mana_cost())
+        self.assertEqual(6, game.other_player.hand[1].mana_cost())
 
         game.play_single_turn()
 
-        self.assertEqual(5, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(6, game.current_player.hand[1].mana_cost(game.current_player))
+        self.assertEqual(5, game.current_player.hand[0].mana_cost())
+        self.assertEqual(6, game.current_player.hand[1].mana_cost())
 
     def test_StoneskinGargoyle(self):
         game = generate_game_for(ConeOfCold,
@@ -3445,7 +3445,7 @@ class TestCommon(unittest.TestCase, TestUtilities):
         game = generate_game_for([Mechwarper, HarvestGolem], StonetuskBoar, CardTestingAgent, DoNothingAgent)
 
         # Harvest Golem is initial 3 cost
-        self.assertEqual(3, game.players[0].hand[1].mana_cost(game.players[0]))
+        self.assertEqual(3, game.players[0].hand[1].mana_cost())
 
         for turn in range(0, 3):
             game.play_single_turn()
@@ -3455,7 +3455,7 @@ class TestCommon(unittest.TestCase, TestUtilities):
 
         # Harvest Golem (MECH) should now have a cost of 2
         self.assertEqual("Harvest Golem", game.players[0].hand[0].name)
-        self.assertEqual(2, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(2, game.players[0].hand[0].mana_cost())
 
         # Kill the Mechwarper
         m = game.players[0].minions[0]
@@ -3464,7 +3464,7 @@ class TestCommon(unittest.TestCase, TestUtilities):
 
         # Harvest Golem should be back at 3 again
         self.assertEqual("Harvest Golem", game.players[0].hand[0].name)
-        self.assertEqual(3, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(3, game.players[0].hand[0].mana_cost())
 
     def test_ClockworkGiant(self):
         game = generate_game_for([Mechwarper, ClockworkGiant], StonetuskBoar, OneCardPlayingAgent, DoNothingAgent)
@@ -3473,7 +3473,7 @@ class TestCommon(unittest.TestCase, TestUtilities):
 
         self.assertEqual(5, len(game.players[1].hand))
         # Initial cost is 12, opponent have 5 cards in hand, 12 - 5 = 7
-        self.assertEqual(7, game.players[0].hand[1].mana_cost(game.players[0]))
+        self.assertEqual(7, game.players[0].hand[1].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
@@ -3481,7 +3481,7 @@ class TestCommon(unittest.TestCase, TestUtilities):
         self.assertEqual(6, len(game.players[1].hand))
         self.assertEqual(1, len(game.players[0].minions))
         # Initial cost is 12, opponent have 6 cards in hand and you have Mechwarper in play, 12 - 6 - 1 = 5
-        self.assertEqual(5, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(5, game.players[0].hand[0].mana_cost())
 
     def test_ArmorPlating(self):
         game = generate_game_for(ArmorPlating, StonetuskBoar, OneCardPlayingAgent, OneCardPlayingAgent)
@@ -4566,3 +4566,32 @@ class TestCommon(unittest.TestCase, TestUtilities):
         self.assertEqual(1, len(game.current_player.minions))
         self.assertEqual(2, game.current_player.minions[0].calculate_attack())
         self.assertEqual(4, game.current_player.minions[0].calculate_max_health())
+
+    def test_EmperorThaurissan(self):
+        game = generate_game_for(EmperorThaurissan, Assassinate, OneCardPlayingAgent, OneCardPlayingAgent)
+
+        for turn in range(11):
+            game.play_single_turn()
+
+        self.assertEqual(8, len(game.current_player.hand))
+        for card in game.current_player.hand:
+            self.assertEqual(5, card.mana_cost())
+
+        self.assertEqual(10, len(game.other_player.hand))
+        for card in game.other_player.hand:
+            if card.name != "The Coin":
+                self.assertEqual(5, card.mana_cost())
+
+        game.play_single_turn()
+        game.play_single_turn()
+
+        self.assertEqual(8, len(game.current_player.hand))
+        for card in game.current_player.hand[:-1]:
+            self.assertEqual(4, card.mana_cost())
+
+        self.assertEqual(5, game.current_player.hand[-1].mana_cost())
+
+        self.assertEqual(9, len(game.other_player.hand))
+        for card in game.other_player.hand:
+            if card.name != "The Coin":
+                self.assertEqual(5, card.mana_cost())

--- a/tests/card_tests/rogue_tests.py
+++ b/tests/card_tests/rogue_tests.py
@@ -409,7 +409,7 @@ class TestRogue(unittest.TestCase):
         game.play_single_turn()
         self.assertEqual(3, len(game.players[0].hand))
         self.assertEqual(0, len(game.players[0].minions))
-        self.assertEqual(0, game.players[0].hand[2].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[2].mana_cost())
 
     def test_Shiv(self):
         game = generate_game_for(Shiv, StonetuskBoar, CardTestingAgent, DoNothingAgent)

--- a/tests/card_tests/shaman_tests.py
+++ b/tests/card_tests/shaman_tests.py
@@ -294,13 +294,13 @@ class TestShaman(unittest.TestCase):
             game.play_single_turn()
 
         # Far Sight should have been played, our latest card should cost 3 - 3 = 0
-        self.assertEqual(0, game.players[0].hand[-1].mana_cost(game.players[0]))
-        self.assertEqual(3, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[-1].mana_cost())
+        self.assertEqual(3, game.players[0].hand[0].mana_cost())
         # Draw a card to make sure the new card doesn't get the effect
         game.players[0].draw()
-        self.assertEqual(3, game.players[0].hand[-1].mana_cost(game.players[0]))
+        self.assertEqual(3, game.players[0].hand[-1].mana_cost())
         # Our old card shouldn't have been affected
-        self.assertEqual(0, game.players[0].hand[-2].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[-2].mana_cost())
 
     def test_FeralSpirit(self):
         game = generate_game_for(FeralSpirit, StonetuskBoar, CardTestingAgent, DoNothingAgent)

--- a/tests/card_tests/warlock_tests.py
+++ b/tests/card_tests/warlock_tests.py
@@ -433,7 +433,7 @@ class TestWarlock(unittest.TestCase):
 
         self.assertEqual(1, len(game.players[0].minions))
         self.assertEqual('Wisp', game.players[0].hand[0].name)
-        self.assertEqual(0, game.players[0].hand[0].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[0].mana_cost())
 
     def test_SummoningPortal_Mechwarper(self):
         game = generate_game_for([SummoningPortal, Mechwarper, SpiderTank], StonetuskBoar,
@@ -442,7 +442,7 @@ class TestWarlock(unittest.TestCase):
             game.play_single_turn()
 
         self.assertEqual(2, len(game.current_player.minions))
-        self.assertEqual(0, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(0, game.current_player.hand[0].mana_cost())
 
     def test_BloodImp(self):
         game = generate_game_for(BloodImp, StonetuskBoar, OneCardPlayingAgent, DoNothingAgent)

--- a/tests/copy_tests.py
+++ b/tests/copy_tests.py
@@ -623,8 +623,8 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
 
         game = game.copy()
         # Make sure the other frostbolts have been properly reduced
-        self.assertEqual(1, game.current_player.hand[1].mana_cost(game.current_player))
-        self.assertEqual(1, game.current_player.hand[2].mana_cost(game.current_player))
+        self.assertEqual(1, game.current_player.hand[1].mana_cost())
+        self.assertEqual(1, game.current_player.hand[2].mana_cost())
 
         game.play_single_turn()
         game.play_single_turn()
@@ -633,7 +633,7 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
         self.assertEqual(0, len(game.current_player.minions))
 
         # Make sure that the cards in hand are no longer reduced
-        self.assertEqual(2, game.current_player.hand[0].mana_cost(game.current_player))
+        self.assertEqual(2, game.current_player.hand[0].mana_cost())
 
     def test_Loatheb(self):
         game = generate_game_for(Loatheb, [Assassinate, BoulderfistOgre], OneCardPlayingAgent, CardTestingAgent)
@@ -643,13 +643,13 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
 
         game = game.copy()
 
-        self.assertEqual(10, game.other_player.hand[0].mana_cost(game.other_player))
-        self.assertEqual(6, game.other_player.hand[1].mana_cost(game.other_player))
+        self.assertEqual(10, game.other_player.hand[0].mana_cost())
+        self.assertEqual(6, game.other_player.hand[1].mana_cost())
 
         game.play_single_turn()
 
-        self.assertEqual(5, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(6, game.current_player.hand[1].mana_cost(game.current_player))
+        self.assertEqual(5, game.current_player.hand[0].mana_cost())
+        self.assertEqual(6, game.current_player.hand[1].mana_cost())
 
     def test_KirinTorMage(self):
         game = generate_game_for([KirinTorMage, BoulderfistOgre, Spellbender],
@@ -663,13 +663,13 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
             new_game = game.copy()
             self.assertEqual(1, len(new_game.current_player.minions))
             self.assertEqual("Kirin Tor Mage", new_game.current_player.minions[0].card.name)
-            self.assertEqual(0, new_game.current_player.hand[1].mana_cost(new_game.current_player))
+            self.assertEqual(0, new_game.current_player.hand[1].mana_cost())
             self.assertEqual("Spellbender", new_game.current_player.hand[1].name)
 
         game.other_player.bind_once("turn_ended", check_secret_cost)
         game.play_single_turn()
         new_game._end_turn()
-        self.assertEqual(3, new_game.current_player.hand[1].mana_cost(new_game.current_player))
+        self.assertEqual(3, new_game.current_player.hand[1].mana_cost())
         self.assertEqual("Spellbender", new_game.current_player.hand[1].name)
 
     def test_WaterElemental(self):
@@ -1167,7 +1167,7 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
         self.assertEqual(0, len(game.players[1].minions))
         self.assertEqual(4, len(game.players[0].hand))
         self.assertEqual(7, len(game.players[1].hand))
-        self.assertEqual(4, game.players[1].hand[6].mana_cost(game.players[1]))
+        self.assertEqual(4, game.players[1].hand[6].mana_cost())
         self.assertEqual(0, len(game.players[0].secrets))
         self.assertEqual(30, game.players[0].hero.health)
         game.play_single_turn()
@@ -1177,8 +1177,8 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
         self.assertEqual(0, len(game.current_player.minions))
         self.assertEqual(30, game.players[0].hero.health)
         self.assertEqual(8, len(game.players[1].hand))
-        self.assertEqual(4, game.players[1].hand[5].mana_cost(game.players[1]))
-        self.assertEqual(4, game.players[1].hand[7].mana_cost(game.players[1]))
+        self.assertEqual(4, game.players[1].hand[5].mana_cost())
+        self.assertEqual(4, game.players[1].hand[7].mana_cost())
 
     def test_Shadowstep(self):
         game = generate_game_for([StonetuskBoar, Shadowstep], StonetuskBoar, PlayAndAttackAgent,
@@ -1189,7 +1189,7 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
         game = game.copy()
         self.assertEqual(3, len(game.players[0].hand))
         self.assertEqual(0, len(game.players[0].minions))
-        self.assertEqual(0, game.players[0].hand[2].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[2].mana_cost())
 
     def test_UnboundElemental(self):
         game = generate_game_for([UnboundElemental, DustDevil, DustDevil], StonetuskBoar, OneCardPlayingAgent,
@@ -1287,13 +1287,13 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
         for turn in range(0, 10):
             game.play_single_turn()
         game = game.copy()
-        self.assertEqual(0, game.players[0].hand[0].mana_cost(game.players[0]))
-        self.assertEqual(8, game.players[0].hand[1].mana_cost(game.players[0]))
+        self.assertEqual(0, game.players[0].hand[0].mana_cost())
+        self.assertEqual(8, game.players[0].hand[1].mana_cost())
 
         game.play_single_turn()
 
-        self.assertEqual(5, game.players[0].hand[0].mana_cost(game.players[0]))
-        self.assertEqual(0, game.players[0].hand[1].mana_cost(game.players[0]))
+        self.assertEqual(5, game.players[0].hand[0].mana_cost())
+        self.assertEqual(0, game.players[0].hand[1].mana_cost())
 
     def test_BaronGeddon(self):
         game = generate_game_for(BaronGeddon, MassDispel, OneCardPlayingAgent, CardTestingAgent)
@@ -1595,14 +1595,14 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
             game.play_single_turn()
         game = game.copy()
         self.assertEqual(1, len(game.current_player.minions))
-        self.assertEqual(5, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(4, game.other_player.hand[0].mana_cost(game.other_player))
-        self.assertEqual(3, game.other_player.hand[1].mana_cost(game.other_player))
+        self.assertEqual(5, game.current_player.hand[0].mana_cost())
+        self.assertEqual(4, game.other_player.hand[0].mana_cost())
+        self.assertEqual(3, game.other_player.hand[1].mana_cost())
         game.current_player.minions[0].silence()
         game = game.copy()
-        self.assertEqual(3, game.current_player.hand[0].mana_cost(game.current_player))
-        self.assertEqual(2, game.other_player.hand[0].mana_cost(game.other_player))
-        self.assertEqual(3, game.other_player.hand[1].mana_cost(game.other_player))
+        self.assertEqual(3, game.current_player.hand[0].mana_cost())
+        self.assertEqual(2, game.other_player.hand[0].mana_cost())
+        self.assertEqual(3, game.other_player.hand[1].mana_cost())
 
     def test_Lightwell(self):
         game = generate_game_for(Lightwell, StonetuskBoar, OneCardPlayingAgent, PredictableAgent)
@@ -2563,7 +2563,7 @@ class TestMinionCopying(unittest.TestCase, TestUtilities):
         self.assertEqual(5, len(game.current_player.hand))
         self.assertTrue(game.current_player.hand[-1].is_minion())
         if game.current_player.hand[-1].mana >= 3:
-            self.assertEqual(3, game.current_player.hand[-1].mana - game.current_player.hand[-1].mana_cost(None))
+            self.assertEqual(3, game.current_player.hand[-1].mana - game.current_player.hand[-1].mana_cost())
 
     def test_MimironsHead(self):
         game = generate_game_for([Mechwarper, SpiderTank, ChillwindYeti, MimironsHead, Deathwing], StonetuskBoar,


### PR DESCRIPTION
Fixed the mana cost calculation for Dread Corsair and Crush, both of which were overriding mana_cost
rather than using a buff.